### PR TITLE
Change execute path

### DIFF
--- a/shape_commentator/main.py
+++ b/shape_commentator/main.py
@@ -7,7 +7,8 @@ initialize_code = """
 __name__ = "__main__"
 __package__ = None
 if "{0.filename}" == "":
-    del __file__
+    if "__file__" in globals():
+        del __file__
 else:
     __file__ = "{0.filename}"
 

--- a/shape_commentator/main.py
+++ b/shape_commentator/main.py
@@ -1,9 +1,16 @@
 import ast
 import sys
 import copy
+import os
 
 initialize_code = """
 __name__ = "__main__"
+__package__ = None
+if "{0.filename}" == "":
+    del __file__
+else:
+    __file__ = "{0.filename}"
+
 def SHAPE_COMMENTATOR_tuple_unpacker(tpl_input):
     class SHAPE_COMMENTATOR_TUPLE_UNPACKER_ENDMARK_TUPLE:
         pass
@@ -47,6 +54,11 @@ def SHAPE_COMMENTATOR_tuple_unpacker(tpl_input):
     result = result[:-1]
     return result
 """
+
+class SHAPE_COMMENTATOR_ENV():
+    def __init__(self):
+        self.globals = {}
+        self.filename = ""
 
 class ShapeNodeTransformer(ast.NodeTransformer):
     def subsciript_dict(self, lineno, col_offset, s):
@@ -114,20 +126,21 @@ class ShapeNodeTransformer(ast.NodeTransformer):
         node_record.value = self.call_tuple_unpacker(node_orig.lineno, node_orig.col_offset, )
         return [node_store_tmp,node_orig,node_record]
 
-def _code_compile(source):
+def _code_compile(source, env):
     tree = ast.parse(source)
     ShapeNodeTransformer().visit(tree)
-    tree.body = ast.parse(initialize_code).body + tree.body
+    initializer = initialize_code.format(env)
+    tree.body = ast.parse(initializer).body + tree.body
     code = compile(tree,'<string>','exec')
     return code
 
-def _execute(source,globals,locals=None):
+def _execute(source, env):
     r"""
-    >>> SHAPE_COMMENTATOR_RESULT={};_execute('import numpy as np\na = np.array([1,2,3,4,5,6])',globals(),locals());SHAPE_COMMENTATOR_RESULT
+    >>> SHAPE_COMMENTATOR_RESULT={};env=SHAPE_COMMENTATOR_ENV();env.globals=globals();_execute('import numpy as np\na = np.array([1,2,3,4,5,6])',env);SHAPE_COMMENTATOR_RESULT
     {'2': '(6,)'}
     """
-    code = _code_compile(source)
-    exec(code, globals, locals)
+    code = _code_compile(source, env)
+    exec(code, env.globals)
 
 # clear comment in Jupyter Notebook / IPython
 def _clear_comment(source, output_func):
@@ -170,12 +183,12 @@ def _preprocess_in_module_mode():
         sys.argv[i] = sys.argv[i+1]
     del sys.argv[len(sys.argv)-1]
 
-def _make_comment(source, globals, output_func):
-    globals['SHAPE_COMMENTATOR_RESULT'] = {}
+def _make_comment(source, env, output_func):
+    env.globals['SHAPE_COMMENTATOR_RESULT'] = {}
     try:
-        _execute(source,globals)
+        _execute(source,env)
     finally:
-        _write_comment(source, globals['SHAPE_COMMENTATOR_RESULT'], output_func)
+        _write_comment(source, env.globals['SHAPE_COMMENTATOR_RESULT'], output_func)
 
 # comment in Jupyter Notebook / IPython
 def comment(source, globals, locals=None):
@@ -186,8 +199,10 @@ def comment(source, globals, locals=None):
     """
     # delete the cell which runs shape_commentator
     exec("In[len(In)-1] = ''", globals)
+    env = SHAPE_COMMENTATOR_ENV()
+    env.globals = globals
     print_func = lambda line:sys.stdout.write(line+"\n")
-    _make_comment(source, globals, print_func)
+    _make_comment(source, env, print_func)
 
 # clear comment in Jupyter Notebook / IPython
 def clear(source):
@@ -206,4 +221,7 @@ def main():
         output_func = lambda x: f_w.write(x + "\n")
         with open(filename) as f:
             source = f.read()
-            _make_comment(source, globals(), output_func)
+            env = SHAPE_COMMENTATOR_ENV()
+            env.globals = globals()
+            env.filename = filename
+            _make_comment(source, env, output_func)

--- a/shape_commentator/print_comment.py
+++ b/shape_commentator/print_comment.py
@@ -1,13 +1,16 @@
 import sys
-from .main import _preprocess_in_module_mode, _make_comment
+from .main import _preprocess_in_module_mode, _make_comment, SHAPE_COMMENTATOR_ENV
 
 def print_comment_main():
     _preprocess_in_module_mode()
     filename = sys.argv[0]
+    env = SHAPE_COMMENTATOR_ENV()
+    env.globals = globals()
+    env.filename = filename
     print_func = lambda line:sys.stdout.write(line+"\n")
     with open(filename) as f:
         source = f.read()
-        _make_comment(source, globals(), print_func)
+        _make_comment(source, env, print_func)
 
 if __name__ == "__main__":
     print_comment_main()

--- a/tests/input_scripts/filepath.py
+++ b/tests/input_scripts/filepath.py
@@ -1,0 +1,3 @@
+print(__file__)
+print(__package__)
+print(__name__)

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -22,7 +22,7 @@ remove_tested_scripts(){
 rm_if_exists(){
     file_names=$1
     if [ -e $file_names ];then
-        rm $file_names
+        echo $file_names | xargs rm
     fi
 }
 

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -16,7 +16,7 @@ remove_tested_scripts(){
     rm_if_exists $BATS_TEST_DIRNAME/input_scripts/*.commented.py
     rm_if_exists $BATS_TEST_DIRNAME/input_scripts/2/*.commented.py
     rm_if_exists $BATS_TEST_DIRNAME/input_scripts/3/*.commented.py
-    rm_if_exists $BATS_TEST_DIRNAME/result
+    rm_if_exists $BATS_TEST_DIRNAME/tmp_result*
 }
  
 rm_if_exists(){
@@ -55,9 +55,9 @@ compare_module_result(){
 # shape_commentator.comment(src, globals())
 compare_method_comment_result(){
     SCRIPT_NAME=$(get_script_path $1)
-    python $BATS_TEST_DIRNAME/method_comment.py $BATS_TEST_DIRNAME/input_scripts/$SCRIPT_NAME > $BATS_TEST_DIRNAME/result
+    python $BATS_TEST_DIRNAME/method_comment.py $BATS_TEST_DIRNAME/input_scripts/$SCRIPT_NAME > $BATS_TEST_DIRNAME/tmp_result
 
-    file_commented=$BATS_TEST_DIRNAME/result
+    file_commented=$BATS_TEST_DIRNAME/tmp_result
     file_correct=$BATS_TEST_DIRNAME/correct_scripts/$SCRIPT_NAME.commented.py
     diff $file_commented $file_correct
 }
@@ -65,9 +65,9 @@ compare_method_comment_result(){
 # shape_commentator.clear(src)
 compare_method_clear_result(){
     SCRIPT_NAME=$(get_script_path $1)
-    python $BATS_TEST_DIRNAME/method_clear.py $BATS_TEST_DIRNAME/input_scripts/$SCRIPT_NAME > $BATS_TEST_DIRNAME/result
+    python $BATS_TEST_DIRNAME/method_clear.py $BATS_TEST_DIRNAME/input_scripts/$SCRIPT_NAME > $BATS_TEST_DIRNAME/tmp_result
 
-    file_commented=$BATS_TEST_DIRNAME/result
+    file_commented=$BATS_TEST_DIRNAME/tmp_result
     file_correct=$BATS_TEST_DIRNAME/correct_scripts/$SCRIPT_NAME.commented.py
     diff $file_commented $file_correct
 }
@@ -75,9 +75,9 @@ compare_method_clear_result(){
 # python -m shape_commentator.print_clear script_name
 compare_module_print_clear_result(){
     SCRIPT_NAME=$(get_script_path $1)
-    python -m shape_commentator.print_clear $BATS_TEST_DIRNAME/input_scripts/$SCRIPT_NAME > $BATS_TEST_DIRNAME/result
+    python -m shape_commentator.print_clear $BATS_TEST_DIRNAME/input_scripts/$SCRIPT_NAME > $BATS_TEST_DIRNAME/tmp_result
     
-    file_commented=$BATS_TEST_DIRNAME/result
+    file_commented=$BATS_TEST_DIRNAME/tmp_result
     file_correct=$BATS_TEST_DIRNAME/correct_scripts/$SCRIPT_NAME.commented.py
     diff $file_commented $file_correct
 }
@@ -85,11 +85,23 @@ compare_module_print_clear_result(){
 # python -m shape_commentator.print_comment script_name
 compare_module_print_comment_result(){
     SCRIPT_NAME=$(get_script_path $1)
-    python -m shape_commentator.print_comment $BATS_TEST_DIRNAME/input_scripts/$SCRIPT_NAME > $BATS_TEST_DIRNAME/result
+    python -m shape_commentator.print_comment $BATS_TEST_DIRNAME/input_scripts/$SCRIPT_NAME > $BATS_TEST_DIRNAME/tmp_result
     
-    file_commented=$BATS_TEST_DIRNAME/result
+    file_commented=$BATS_TEST_DIRNAME/tmp_result
     file_correct=$BATS_TEST_DIRNAME/correct_scripts/$SCRIPT_NAME.commented.py
     diff $file_commented $file_correct
+}
+
+# 
+compare_print_result(){
+    SCRIPT_NAME=$(get_script_path $1)
+    python -m shape_commentator $BATS_TEST_DIRNAME/input_scripts/$SCRIPT_NAME > $BATS_TEST_DIRNAME/tmp_result1
+    python $BATS_TEST_DIRNAME/input_scripts/$SCRIPT_NAME > $BATS_TEST_DIRNAME/tmp_result2
+
+    file_commented=$BATS_TEST_DIRNAME/tmp_result1
+    file_correct=$BATS_TEST_DIRNAME/tmp_result2
+    diff $file_commented $file_correct
+
 }
 
 @test "NumPy (Module)" {
@@ -144,10 +156,14 @@ compare_module_print_comment_result(){
     compare_module_print_clear_result "print_clear.py"
 }
 
-@test "Modle print_comment" {
+@test "Module print_comment" {
     compare_module_print_comment_result "print_comment.py"
 }
 
 @test "Method shape_commentator.clear(src)" {
     compare_method_clear_result "print_clear.py"
+}
+
+@test "__file__ __package__ __name__ is same" {
+    compare_print_result "filepath.py"
 }

--- a/tests/tmp_result2
+++ b/tests/tmp_result2
@@ -1,0 +1,3 @@
+/Users/shibata/other/shape-commentator/shape_commentator/tests/input_scripts/filepath.py
+None
+__main__

--- a/tests/tmp_result2
+++ b/tests/tmp_result2
@@ -1,3 +1,0 @@
-/Users/shibata/other/shape-commentator/shape_commentator/tests/input_scripts/filepath.py
-None
-__main__


### PR DESCRIPTION
__file__などの変数を利用するスクリプトをshape_commentatorにかけると，__file__がshape_commentatorのファイル名だった問題を修正．
IPython では，__file__は定義されていないことに注意．
publicなメソッドでは，env = SHAPE_COMMENTATOR_ENVを生成して，`_`から始まる(慣例的)privateメソッドではenvを利用する．