### PR TITLE
fix state bug on jupyter_ext

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import io
 
-VERSION = "0.6.1"
+VERSION = "0.6.2"
 
 def get_test_version():
     import requests

--- a/shape_commentator/jupyter_ext.py
+++ b/shape_commentator/jupyter_ext.py
@@ -3,6 +3,8 @@ from .main import make_comment, clear_comment, SHAPE_COMMENTATOR_ENV
 from IPython.display import Javascript, display
 import json
 
+ENV_GLOBALS = None
+
 class SHAPE_COMMENTATOR_ENV():
     def __init__(self):
         self.globals = {}
@@ -13,7 +15,7 @@ def shape_comment(line, cell):
     output = []
     output_func = lambda x: output.append(x)
     env = SHAPE_COMMENTATOR_ENV()
-    env.globals = globals()
+    env.globals = ENV_GLOBALS if ENV_GLOBALS is not None else globals()
     try:
         make_comment(cell, env, output_func)
     finally:


### PR DESCRIPTION
jupyter_extで，前実行したセルの状態が引き継げない問題．
jupyter-shape-commentatorで，ENV_GLOBALSにglobals()を代入することで解決した．